### PR TITLE
Fix public-url for the app

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test": "aragon contracts test",
     "compile": "aragon contracts compile",
     "sync-assets": "copy-aragon-ui-assets -n aragon-ui ./dist",
-    "build:app": "parcel build app/index.html -d dist/ --public-url . --no-cache",
+    "build:app": "parcel build app/index.html -d dist/ --public-url \".\" --no-cache",
     "build:script": "parcel build app/script.js -d dist/ --no-cache",
     "build": "npm run sync-assets && npm run build:app && npm run build:script",
     "publish:patch": "aragon apm publish patch",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test": "aragon contracts test",
     "compile": "aragon contracts compile",
     "sync-assets": "copy-aragon-ui-assets -n aragon-ui ./dist",
-    "build:app": "parcel build app/index.html -d dist/ --public-url '.' --no-cache",
+    "build:app": "parcel build app/index.html -d dist/ --public-url . --no-cache",
     "build:script": "parcel build app/script.js -d dist/ --no-cache",
     "build": "npm run sync-assets && npm run build:app && npm run build:script",
     "publish:patch": "aragon apm publish patch",


### PR DESCRIPTION
I couldn't load the app in the browser due to a bad public-url:

```
GET https://ipfs.eth.aragon.network/ipfs/QmNet13LCsL1exSvYJwu65PyRHAVGnAEWFmHVP2YossfqY/dist/%27.%27/main.3051a028.js net::ERR_ABORTED 404
```
`index.html` had this script tag: `<script src="%27.%27/main.3051a028.js">`

This happened on windows.