### PR TITLE
Add rsync as a dep

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -16,7 +16,8 @@
     "@babel/core": "^7.3.4",
     "@babel/plugin-proposal-class-properties": "^7.3.4",
     "@babel/preset-env": "^7.3.4",
-    "parcel-bundler": "^1.12.3"
+    "parcel-bundler": "^1.12.3",
+    "rsync": "^0.6.1"
   },
   "scripts": {
     "build": "npm run sync-assets && npm run build:app && npm run build:script",


### PR DESCRIPTION
Fixes the `sh: 1: rsync: not found␊` issue in 
https://github.com/aragon/aragon-cli/pull/459/checks?check_run_id=133193102
