### PR TITLE
Update default environment to use open subdomain

### DIFF
--- a/arapp.json
+++ b/arapp.json
@@ -14,7 +14,7 @@
   "environments": {
     "default": {
       "network": "development",
-      "appName": "placeholder-app-name.aragonpm.eth"
+      "appName": "placeholder-app-name.open.aragonpm.eth"
     },
     "rinkeby": {
       "registry": "0x98df287b6c145399aaa709692c8d308357bc085d",


### PR DESCRIPTION
Now that https://github.com/aragon/aragen/pull/33 is used in the snapshot we need to use the open subdomain on default environment.