### PR TITLE
Small changes to be compatible with new publish script

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -12,5 +12,5 @@
   ],
   "screenshots": [{ "src": "/meta/screenshot-1.png" }],
   "start_url": "/index.html",
-  "script": "script.js"
+  "script": "/script.js"
 }

--- a/manifest.json
+++ b/manifest.json
@@ -11,6 +11,6 @@
     }
   ],
   "screenshots": [{ "src": "/meta/screenshot-1.png" }],
-  "start_url": "index.html",
+  "start_url": "/index.html",
   "script": "script.js"
 }

--- a/manifest.json
+++ b/manifest.json
@@ -2,15 +2,15 @@
   "name": "Counter",
   "author": "Placeholder-author",
   "description": "An application for Aragon",
-  "details_url": "/dist/meta/details.md",
+  "details_url": "/meta/details.md",
   "source_url": "https://<placeholder-repository-url>",
-  "icons": [{
-    "src": "/dist/meta/icon.svg",
-    "sizes": "56x56"
-  }],
-  "screenshots": [
-    { "src": "/dist/meta/screenshot-1.png" }
+  "icons": [
+    {
+      "src": "/meta/icon.svg",
+      "sizes": "56x56"
+    }
   ],
-  "start_url": "/dist/index.html",
-  "script": "/dist/script.js"
+  "screenshots": [{ "src": "/meta/screenshot-1.png" }],
+  "start_url": "index.html",
+  "script": "script.js"
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@aragon/apps-voting": "2.1.0"
   },
   "devDependencies": {
-    "@aragon/cli": "^5.9.7",
+    "@aragon/cli": "^6.0.0",
     "@aragon/test-helpers": "^2.0.0",
     "babel-eslint": "^10.0.2",
     "cross-env": "^5.2.0",
@@ -30,7 +30,7 @@
   "scripts": {
     "prepublishOnly": "aragon contracts compile",
     "start": "npm run start:ipfs",
-    "start:ipfs": "aragon run",
+    "start:ipfs": "aragon run --files dist",
     "start:http": "aragon run --http localhost:8001 --http-served-from ./dist",
     "start:ipfs:template": "npm run start:ipfs -- --template Template --template-init @ARAGON_ENS",
     "start:http:template": "npm run start:http -- --template Template --template-init @ARAGON_ENS",


### PR DESCRIPTION
Now the publish script not include all folder by default. It will only include the minimum necessary files (`manifest.json`, `artifact.json` and `code.sol`). 

Then we need to include the `dist` folder to include the App front-end.

TODO:

- [ ] Same PR on bare boilerplate