### PR TITLE
Adds Truffle dependency so that tests can run

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "eslint-plugin-standard": "^4.0.0",
     "ethlint": "^1.2.4",
     "prettier": "^1.18.2",
-    "solidity-coverage": "^0.6.2"
+    "solidity-coverage": "^0.6.2",
+    "truffle": "^4.1.14"
   },
   "scripts": {
     "prepublishOnly": "aragon contracts compile",


### PR DESCRIPTION
Fix item 2 of https://github.com/aragon/aragon-cli/issues/716

> "Running npm test fails. The script ganache-cli uses npx truffle test, but there is no Truffle dependency installed in the boilerplate React project, so it assumes that you have a global truffle version installed. If you don't, it'll use npx and hence lock into the latest version, Truffle 5, which fails because the project needs to use Truffle 4. The boilerplate React project should have the Truffle 4 dependency installed locally."

This PR simply adds the Truffle 4.1.14 dev-dependency to the boilerplate and allows `npm test` to run flawlessly. 