### PR TITLE
Fix event name & remove prepublish script

### DIFF
--- a/contracts/Template.sol
+++ b/contracts/Template.sol
@@ -27,7 +27,7 @@ contract TemplateBase is APMNamehash {
     ENS public ens;
     DAOFactory public fac;
 
-    event DeployInstance(address dao);
+    event DeployDAO(address dao);
     event InstalledApp(address appProxy, bytes32 appId);
 
     constructor(DAOFactory _fac, ENS _ens) public {
@@ -101,6 +101,6 @@ contract Template is TemplateBase {
         acl.revokePermission(this, acl, acl.CREATE_PERMISSIONS_ROLE());
         acl.setPermissionManager(root, acl, acl.CREATE_PERMISSIONS_ROLE());
 
-        emit DeployInstance(dao);
+        emit DeployDAO(dao);
     }
 }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "truffle": "^4.1.14"
   },
   "scripts": {
-    "prepublishOnly": "aragon contracts compile",
     "start": "npm run start:ipfs",
     "start:ipfs": "aragon run --files dist",
     "start:http": "aragon run --http localhost:8001 --http-served-from ./dist",


### PR DESCRIPTION
This PR will fix the issue `✖ Cannot read property 'returnValues' of undefined`
