### PR TITLE
Add ganache-cli dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "eslint-plugin-react": "^7.14.2",
     "eslint-plugin-standard": "^4.0.0",
     "ethlint": "^1.2.4",
+    "ganache-cli": "^6.0.0",
     "prettier": "^1.18.2",
     "solidity-coverage": "^0.6.2",
     "truffle": "^4.1.14"


### PR DESCRIPTION
closes #79 

The `@aragon/test-helpers` use `ganache-cli` as a peer dependency