### PR TITLE
Go back to DeployInstance event

### DIFF
--- a/contracts/Template.sol
+++ b/contracts/Template.sol
@@ -27,7 +27,7 @@ contract TemplateBase is APMNamehash {
     ENS public ens;
     DAOFactory public fac;
 
-    event DeployDAO(address dao);
+    event DeployInstance(address dao);
     event InstalledApp(address appProxy, bytes32 appId);
 
     constructor(DAOFactory _fac, ENS _ens) public {
@@ -101,6 +101,6 @@ contract Template is TemplateBase {
         acl.revokePermission(this, acl, acl.CREATE_PERMISSIONS_ROLE());
         acl.setPermissionManager(root, acl, acl.CREATE_PERMISSIONS_ROLE());
 
-        emit DeployDAO(dao);
+        emit DeployInstance(dao);
     }
 }


### PR DESCRIPTION
Now that we have backward compatibility we can go back to `DeployInstance` event until we merge #69 